### PR TITLE
Adding support to remove a specific listener for an event

### DIFF
--- a/lib/chuckt.js
+++ b/lib/chuckt.js
@@ -108,11 +108,23 @@ window.epixa || (window.epixa = {});
    *
    * @param event
    */
-  ChuckT.prototype.removeListeners = function(event) {
+  ChuckT.prototype.removeListeners = function(event, callback) {
     if (typeof event === 'undefined') {
       this.listeners = {};
     } else {
-      delete this.listeners[event];
+      if (typeof listener !== "undefined") {
+        var len = this.listeners[event].length;
+
+        for (var i = 0; i < len; i ++) {
+          if (this.listeners[event][i] === callback) {
+            this.listeners[event].splice(i, 1);
+            len --;
+            i --;
+          }
+        }
+      } else {
+        delete this.listeners[event];
+      }
     }
   };
 

--- a/lib/chuckt.js
+++ b/lib/chuckt.js
@@ -112,7 +112,7 @@ window.epixa || (window.epixa = {});
     if (typeof event === 'undefined') {
       this.listeners = {};
     } else {
-      if (typeof listener !== "undefined") {
+      if (typeof callback !== "undefined") {
         var len = this.listeners[event].length;
 
         for (var i = 0; i < len; i ++) {


### PR DESCRIPTION
This could be handy when wanting to remove specific callbacks instead of all callbacks for a given event.
